### PR TITLE
fixed weird NA values #157

### DIFF
--- a/code/consolidateLatestZips.R
+++ b/code/consolidateLatestZips.R
@@ -185,8 +185,12 @@ rm(be02)
 ## BE03
 
 # 32990 found, 32990 expected
+# BE03_Z had an issue where it's entries were saved as characters, not numerics.
 be03 <- read.csv('../data_final/BE03_Z.csv') |>
-  mutate(GEOID = str_pad(ZCTA, width=5, side='left', pad='0')) |>
+  mutate(GEOID = str_pad(ZCTA, width=5, side='left', pad='0'),
+         alcDens = as.numeric(alcDens),
+         alPerCap = as.numeric(alcPerCap),
+         alcTotal = as.numeric(alcTotal)) |>
   select(-G_ZCTA, -ZCTA, -totPopE)
 
 zipDf <- zipDf |> merge(be03, by='GEOID', all.x = TRUE)


### PR DESCRIPTION
As documented on the [issue itself](https://github.com/GeoDaCenter/opioid-policy-scan/issues/157#issuecomment-2299420590), the weird NA values appear to have only effected Z_Latest, and were caused by a V1 data file consisting of all strings. 